### PR TITLE
Add `placeShellFlag` call in init

### DIFF
--- a/src/handling.ts
+++ b/src/handling.ts
@@ -72,7 +72,8 @@ export class HmOog {
 
         await this.updateShell();
         this.consumeLines(); // Discard old output
-
+        await this.placeShellFlag();
+        
         this.didInit = true;
     }
 


### PR DESCRIPTION
There is no flag placed for the first `runCommand` call, which means that it's simply looking for the command body to determine where to start from. However, since the code search from the top down, older instances of calls with the same body are found before newer ones, leading to a case where you end up with 100's of extra lines for the initial call.

To fix this, after consuming old lines in init, run `placeShellFlag`, so that subsequent calls start lower down, where expected.